### PR TITLE
added :state-state option to refresh card state on reload

### DIFF
--- a/src/devcards/core.cljs
+++ b/src/devcards/core.cljs
@@ -225,13 +225,15 @@
        :componentDidUpdate
        (fn [_ _]
          (this-as
-          this
-          (let [atom    (get-state this :data_atom)
-                card    (get-props this :card)
-                options (:options card)
-                data    @(:initial-data card)]
-            (if (and (:static-state options) (not= @atom data))
-              (reset! atom data)))))
+           this
+           (let [atom    (get-state this :data_atom)
+                 card    (get-props this :card)
+                 options (:options card)]
+             (when (:static-state options)
+               (let [initial-data (:initial-data card)
+                     data         (if (atom-like? initial-data) @initial-data initial-data)]
+                 (if (not= @atom data)
+                   (reset! atom data)))))))
        :componentWillMount
        (if (html-env?)
          (fn []

--- a/src/devcards/core.cljs
+++ b/src/devcards/core.cljs
@@ -218,6 +218,8 @@
     (fn [this] (get-state this :data_atom))
     (fn [this] (wrangle-inital-data this))))
 
+(declare atom-like?)
+
 (defonce-react-class DevcardBase
   #js {:getInitialState
        (fn []

--- a/src/devcards/core.cljs
+++ b/src/devcards/core.cljs
@@ -222,6 +222,16 @@
   #js {:getInitialState
        (fn []
          #js {:unique_id (gensym 'devcards-base-)})
+       :componentDidUpdate
+       (fn [_ _]
+         (this-as
+          this
+          (let [atom    (get-state this :data_atom)
+                card    (get-props this :card)
+                options (:options card)
+                data    @(:initial-data card)]
+            (if (and (:static-state options) (not= @atom data))
+              (reset! atom data)))))
        :componentWillMount
        (if (html-env?)
          (fn []
@@ -367,7 +377,7 @@
                       {:label :initial-data
                        :message "should be an Atom or a Map or nil."
                        :value initial-data})]
-                 (mapv #(booler? % (:options opts)) [:frame :heading :padding :inspect-data :watch-atom :history])))))
+                 (mapv #(booler? % (:options opts)) [:frame :heading :padding :inspect-data :watch-atom :history :static-state])))))
     [{:message "Card should be a Map."
       :value   opts}]))
 
@@ -380,6 +390,7 @@
                              :heading false
                              :padding false
                              :inspect-data true
+                             :static-state false
                              :watch-atom nil
                              :history nil})))
 


### PR DESCRIPTION
Hi,

One issue that I really had recurring here is that most of my Om components are just for rendering (their state doesn't change) but I often change their state on code while developing it and because the component state is retained I have to work around to get the new state there.

This request is a proposal for a new option called `:static-state` (please let me know if you have a better name). When you set that to true it will force the component state to be updated on the code reload, ensuring the latest state there without extra friction.