### PR TITLE
Support react v0.14

### DIFF
--- a/src/devcards/core.cljs
+++ b/src/devcards/core.cljs
@@ -25,8 +25,8 @@
   "Make a react Symbol the same way as React 0.14"
   (or (and (exists? js/Symbol)
            (fn? js/Symbol)
-           (.-for js/Symbol)
-           ((.-for js/Symbol) "react.element"))
+           (aget js/Symbol "for")
+           ((aget js/Symbol "for") "react.element"))
       0xeac7))
 
 ;; its possible to record the meta-data for the loaded ns's being

--- a/src/devcards/core.cljs
+++ b/src/devcards/core.cljs
@@ -21,6 +21,14 @@
 ;; this channel is only used for card registration notifications
 (defonce devcard-event-chan (chan))
 
+(def react-element-type-symbol
+  "Make a react Symbol the same way as React 0.14"
+  (or (and (exists? js/Symbol)
+           (fn? js/Symbol)
+           (.-for js/Symbol)
+           ((.-for js/Symbol) "react.element"))
+      0xeac7))
+
 ;; its possible to record the meta-data for the loaded ns's being
 ;; shipped by figwheel, by ataching a before load listener and storing
 ;; the meta data, might be better to have figwheel do that.
@@ -358,7 +366,9 @@
          :value x})))
 
 (defn react-element? [main-obj]
-  (aget main-obj "_isReactElement"))
+  (or (aget main-obj "_isReactElement") ;; react 0.13
+      (= react-element-type-symbol      ;; react 0.14
+         (aget main-obj "$$typeof"))))
 
 (defn validate-card-options [opts]
   (if (map? opts)

--- a/src/devcards/system.cljs
+++ b/src/devcards/system.cljs
@@ -412,7 +412,8 @@
 (defn start-ui-with-renderer [channel renderer]
   (defonce devcards-ui-setup
     (do
-      (js/React.initializeTouchEvents true)
+      (when (exists? js/React.initializeTouchEvents)
+        (js/React.initializeTouchEvents true))
       (go
         (<! (load-data-from-channel! channel))
 
@@ -434,7 +435,8 @@
 (defn start-ui [channel]
   (defonce devcards-ui-setup
     (do
-      (js/React.initializeTouchEvents true)
+      (when (exists? js/React.initializeTouchEvents)
+        (js/React.initializeTouchEvents true))
       (render-base-if-necessary!)
       (go
         ;; initial load


### PR DESCRIPTION
Hi , this adds minimal support for react 0.14 without affecting 0.13 users.

React 0.14 removes React.initializeTouchEvents as it's no longer
needed.

_isReactElement was removed and replaced with the $$typeof field which
contains an ES6 symbol if supported or a number.

Warnings are visible for 0.14 which could be stopped by using ReactDOM for the
render and findDOMNode functions etc.

https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#breaking-changes
https://github.com/facebook/react/pull/4832