### PR TITLE
Move CSS affecting devcard contents to addons.css

### DIFF
--- a/resources/public/devcards/css/com_rigsomelight_devcards.css
+++ b/resources/public/devcards/css/com_rigsomelight_devcards.css
@@ -68,10 +68,6 @@ body .hljs {
   border-radius: 4px;
 }
 
-.com-rigsomelight-devcards_rendered-card code {
-  font-size: 90%;
-} 
-
 .com-rigsomelight-devcards-markdown pre code {
   padding: 0;
   font-size: inherit;
@@ -97,12 +93,7 @@ body .hljs {
 .com-rigsomelight-devcards-markdown h2,
 .com-rigsomelight-devcards-markdown h3,
 .com-rigsomelight-devcards-markdown h4,
-.com-rigsomelight-devcards-markdown h5,
-.com-rigsomelight-devcards-base h1,
-.com-rigsomelight-devcards-base h2,
-.com-rigsomelight-devcards-base h3,
-.com-rigsomelight-devcards-base h4,
-.com-rigsomelight-devcards-base h5 {
+.com-rigsomelight-devcards-markdown h5 {
     font-weight: 500;
 }
 
@@ -114,11 +105,6 @@ body .hljs {
     margin-top: 14px;
 }
                                            
-.com-rigsomelight-devcards-base a {
-    color: #428bca;
-    text-decoration: none;
-}
-
 .com-rigsomelight-devcards-markdown code,
 .com-rigsomelight-devcards-markdown kbd,
 .com-rigsomelight-devcards-markdown pre,

--- a/resources/public/devcards/css/com_rigsomelight_devcards_addons.css
+++ b/resources/public/devcards/css/com_rigsomelight_devcards_addons.css
@@ -21,3 +21,20 @@ body {
     font-size: 16px;
     line-height: 1.42857143;
 }
+
+.com-rigsomelight-devcards_rendered-card code {
+    font-size: 90%;
+}
+
+.com-rigsomelight-devcards-base h1,
+.com-rigsomelight-devcards-base h2,
+.com-rigsomelight-devcards-base h3,
+.com-rigsomelight-devcards-base h4,
+.com-rigsomelight-devcards-base h5 {
+    font-weight: 500;
+}
+
+.com-rigsomelight-devcards-base a {
+    color: #428bca;
+    text-decoration: none;
+}


### PR DESCRIPTION
This change makes sure the CSS bundled with Devcards does not interfere
with the CSS used to render components inside a card - if the user has
opted out by excluding com_rigsomelight_devcards_addons.css.

Ref #57 