### PR TITLE
Add optional card options to be passed to start-devcard-ui!

### DIFF
--- a/src/devcards/core.clj
+++ b/src/devcards/core.clj
@@ -11,9 +11,8 @@
    [clojure.java.io :as io])
   (:refer-clojure :exclude (munge defonce)))
 
-(defmacro start-devcard-ui! []
-  `(devcards.core/start-devcard-ui!*))
-
+(defmacro start-devcard-ui! [& [options]]
+  `(devcards.core/start-devcard-ui!* ~options))
 
 #_(defmacro start-single-card-ui! []
   (enable-devcards!)


### PR DESCRIPTION
Fall back to an empty options map. The options are stored in the app state of the system and are merged with each card's custom options in `base-card`.

**Note:** I've tested this with and without options. I've also briefly checked the devcards examples and they seem ok. But since my knowledge of the devcards internals is limited, I don't know whether this change might have other effects that I didn't consider.

Another question is: are card options the only thing we'd ever consider to be passed to `start-devcard-ui!` or should we keep it more flexible by assuming `options` to has a structure like 

    {:default-card-options {:frame false ...}
     ... other options ...}

rather than the one below?

    {:frame false}