### PR TITLE
Story ID: bullets-part2

### DIFF
--- a/src/devcards/util/markdown.cljs
+++ b/src/devcards/util/markdown.cljs
@@ -7,7 +7,7 @@
   (when-let [ws (second (re-matches #"^([\s]*).*"  s))]
     (.-length ws)))
 
-(defn is-bullet-item? [s] (re-matches #"^\s*([*-+]|[0-9]+\.)\s.*" s))
+(defn is-bullet-item? [s] (boolean (re-matches #"^\s*([-*+]|[0-9]+\.)\s.*" s)))
 
 (defn bullets-left-edge "Find the common left edge of bullet lists in a collection of lines."
   [lines]


### PR DESCRIPTION
Bruce, I screwed up on the regex, which in turn makes my left edge trimming break if they use - as the bullet marker. This fixes it (I put - in the regex such that is generated a range instead of char items)