### PR TITLE
Use unique key for html collection elements

### DIFF
--- a/src/devcards/util/edn_renderer.cljs
+++ b/src/devcards/util/edn_renderer.cljs
@@ -33,9 +33,8 @@
 (defn literal [class x]
   (sab/html [:span { :className class :key (get-key)} (utils/pprint-str x)]))
 
-(defn html-val
-  ([index v]
-   (sab/html [:span {:key index} (html v)])))
+(defn html-val [index v]
+  (sab/html [:span {:key index} (html v)]))
 
 (defn join-html [separator coll]
   (interpose-separator (into [] (map-indexed html-val coll))

--- a/src/devcards/util/edn_renderer.cljs
+++ b/src/devcards/util/edn_renderer.cljs
@@ -33,8 +33,12 @@
 (defn literal [class x]
   (sab/html [:span { :className class :key (get-key)} (utils/pprint-str x)]))
 
+(defn html-val
+  ([index v]
+   (sab/html [:span {:key index} (html v)])))
+
 (defn join-html [separator coll]
-  (interpose-separator (mapv html coll)
+  (interpose-separator (into [] (map-indexed html-val coll))
                        separator
                        (separate-fn coll)))
 


### PR DESCRIPTION
- Added function html-val which uses an index to set the key
- Modified join-html to call html-val with an index instead of html

This fixes the following card which complains about duplicate keys in react:
```
(defcard devcard-inspect
  (fn [data _]
    (reagent/as-element
     [:button {:on-click #(swap! data conj ".")} "Just one bite!"]))
  ["."]
  {:inspect-data true})
```