### PR TITLE
Improve Om Next cards story

### DIFF
--- a/example_src/devdemos/core.cljs
+++ b/example_src/devdemos/core.cljs
@@ -1,10 +1,11 @@
-(ns 
+(ns
   ^{:description "Devcards: A high level introduction."
     :rigsomelight-post true}
   devdemos.core
     (:require
      [om.core :as om :include-macros true]
      [om.dom :as dom :include-macros true]
+     [om.next :as omnext :refer-macros [defui]]
      [reagent.core :as reagent]
      [clojure.string :as string]
      [sablono.core :as sab :include-macros true]
@@ -14,7 +15,7 @@
      ;; Notice that I am not including the 'devcards.core namespace
      ;; but only the macros. This helps ensure that devcards will only
      ;; be created when the :devcards is set to true in the build config.
-     [devcards.core :as dc :refer [defcard defcard-doc deftest dom-node]]))
+     [devcards.core :as dc :refer [defcard defcard-doc deftest dom-node defcard-om-next]]))
 
 (def ^:export front-matter
   {:layout false
@@ -292,6 +293,73 @@
   {:height 180 :weight 80} ;; initial data
   {:inspect-data true
    :frame true
+   :history true })
+
+(defn bmi-mutate
+  [{:keys [state]} _ params]
+  (let [[k v] (first params)]
+    {:action #(swap! state assoc k v)}))
+
+(defn bmi-read
+  [{:keys [state]} k {:keys [] :as params}]
+  {:value (get @state k)})
+
+(defn om-next-slider [c param value min max]
+  (sab/html
+   [:input {:type "range" :value value :min min :max max
+            :style {:width "100%"}
+            :on-change (fn [e]
+                         (omnext/transact! c `[(change-bmi-key! {~param ~(.-target.value e)})])
+                         (when (not= param :bmi)
+                           (omnext/transact! c '[(change-bmi-key! {:bmi nil})])))}]))
+
+(defui ^:once BmiComponent
+  static omnext/IQuery
+  (query [this]
+    [:height :weight :bmi])
+  Object
+  (render [this]
+    (let [props (omnext/props this)
+          {:keys [weight height bmi]} (calc-bmi props)
+          [color diagnose] (cond
+                            (< bmi 18.5) ["orange" "underweight"]
+                            (< bmi 25) ["inherit" "normal"]
+                            (< bmi 30) ["orange" "overweight"]
+                            :else ["red" "obese"])]
+      (sab/html
+       [:div
+        [:h3 "BMI calculator"]
+        [:div
+         [:span (str "Height: " (int height) "cm")]
+         (om-next-slider this :height height 100 220)]
+        [:div
+         [:span (str "Weight: " (int weight) "kg")]
+         (om-next-slider this :weight weight 30 150)]
+        [:div
+         [:span (str "BMI: " (int bmi) " ")]
+         [:span {:style {:color color}} diagnose]
+         (om-next-slider this :bmi bmi 10 50)]]))))
+
+(defonce bmi-reconciler
+  (omnext/reconciler {:state {:height 180 :weight 80}
+                      :parser (omnext/parser {:read bmi-read :mutate bmi-mutate})}))
+
+(defcard
+  "# Om Next support
+
+   Here is the same calculator being rendered as an Om Next application.
+   ```
+   (defcard-om-next om-next-support
+     BmiComponent
+     bmi-reconciler
+     {:inspect-data true :history true })
+   ```
+   ")
+
+(defcard-om-next om-next-support
+  BmiComponent
+  bmi-reconciler
+  {:inspect-data true
    :history true })
 
 (defonce re-bmi-data (reagent/atom {:height 180 :weight 80}))

--- a/example_src/devdemos/om_next.cljs
+++ b/example_src/devdemos/om_next.cljs
@@ -27,9 +27,14 @@
 
     Please refer to code of this file to see how these Om Next examples are
     built.
+
+    ### One more thing
+    - If you want to experience the best of a live-programming environment, don't forget to write reloadable code:
+      - `defui ^:once` your components
+      - `defonce` your reconcilers!
 ")
 
-(defui Widget
+(defui ^:once Widget
   Object
   (render [this]
     (sab/html [:h2 "This is an Om Next card, " (:text (om/props this))])))
@@ -54,7 +59,7 @@
 
 (defcard om-next-share-atoms
   (dc/doc
-   "#### You can share an Atom between `om-next-root` cards.
+   "#### You can share an Atom between `om-next-root`/`defcard-om-next` cards.
 
     Interact with the counters below."))
 
@@ -85,27 +90,33 @@
 
 (def om-next-counter-inc (counter inc "inc"))
 
-(defcard-om-next om-next-card-shared-ex-1
-  om-next-counter-inc
+(defonce rec1
   (om/reconciler {:state om-test-atom
                   :parser (om/parser {:read counter-read
                                       :mutate counter-mutate})
                   :shared {:title "First counter "}}))
 
+(defcard-om-next om-next-card-shared-ex-1
+  om-next-counter-inc
+  rec1)
+
 (def om-next-counter-dec (counter dec "dec"))
 
-(defcard-om-next om-next-card-shared-ex-2
-  om-next-counter-dec
+(defonce rec2
   (om/reconciler {:state om-test-atom
                   :parser (om/parser {:read counter-read
                                       :mutate counter-mutate})
                   :shared {:title "Second counter "}}))
 
-(dc/defcard om-test-atom-data
+(defcard-om-next om-next-card-shared-ex-2
+  om-next-counter-dec
+  rec2)
+
+(defcard om-test-atom-data
   "### You can share an Atom with an `edn-card` too:"
   om-test-atom)
 
-(defui UnmountSample
+(defui ^:once UnmountSample
   Object
   (componentDidMount [_]
     (println "mounting"))
@@ -116,31 +127,3 @@
 
 (defcard-om-next sample-om-next-card
   UnmountSample)
-
-(defn display-state [c [k v]]
-  (dom/li nil
-    (str k ": " v)
-    (dom/button #js {:key (str k)
-                     :onClick #(om/update-state! c update k inc)} "inc!")))
-
-(defui ^:once ComponentWithLocalState
-  Object
-  (initLocalState [this]
-    {:a 1
-     :b 2})
-  (render [this]
-    (dom/div nil
-      (map #(display-state this %) (om/get-state this)))))
-
-(defcard-om-next local-state-om-next-card
-  "we can define components with `:once` metadata"
-  ComponentWithLocalState)
-
-(defcard local-state-mock-root
-  "Unfortunately, components will lose their local state upon reload
-   This is also true with a root mocking approach, as demoed in this card"
-  (p/add-root!
-    (om.next/reconciler {:state {}
-                         :parser (om.next/parser {:read (fn [] {:value {}})})})
-    ComponentWithLocalState
-    nil nil))

--- a/src/devcards/core.clj
+++ b/src/devcards/core.clj
@@ -179,33 +179,26 @@
 ;; om next helpers
 
 (defmacro om-next-root
-  ([om-next-comp]
-   (when (utils/devcards-active?)
-     `(om-next-root ~om-next-comp nil {})))
   ([om-next-comp om-next-reconciler]
    (when (utils/devcards-active?)
-     `(om-next-root ~om-next-comp ~om-next-reconciler {})))
-  ([om-next-comp om-next-reconciler options]
-   (when (utils/devcards-active?)
-       `(devcards.core/OmNextDevcard.
-          (let [state# (when-not (om.next/reconciler? ~om-next-reconciler)
-                         (if (map? ~om-next-reconciler)
-                           (atom ~om-next-reconciler)
-                           (atom {})))
+     `(create-idevcard
+       (devcards.core/dom-node*
+        (fn [data-atom# node#]
+          (let [state# (if (map? ~om-next-reconciler) (atom ~om-next-reconciler) data-atom#)
                 reconciler# (if (om.next/reconciler? ~om-next-reconciler)
                               ~om-next-reconciler
                               (om.next/reconciler {:state state#
-                                                   :parser (om.next/parser {:read (fn [] {:value state#})})}))]
-            {:mount-fn #(om.next/add-root! reconciler# ~om-next-comp %)
-             :data_atom (om.next/app-state reconciler#)
-             :reconciler reconciler#
-             :component ~om-next-comp})
-        ~options))))
+                                                   :parser (om.next/parser {:read (fn [] {:value data-atom#})})}))]
+            (om.next/add-root! reconciler# ~om-next-comp node#))))
+       {:watch-atom false})))
+  ([om-next-comp]
+   (when (utils/devcards-active?)
+     `(om-next-root ~om-next-comp nil))))
 
 (defmacro defcard-om-next [& exprs]
   (when (utils/devcards-active?)
-    (let [[vname docu om-next-comp om-next-reconciler options] (parse-card-args exprs 'om-next-root-card)]
-      (card vname docu `(om-next-root ~om-next-comp ~om-next-reconciler) nil options))))
+    (let [[vname docu om-next-comp om-next-reconciler initial-data options] (parse-card-args exprs 'om-next-root-card)]
+      (card vname docu `(om-next-root ~om-next-comp ~om-next-reconciler) initial-data options))))
 
 ;; formatting for markdown cards
 

--- a/src/devcards/core.cljs
+++ b/src/devcards/core.cljs
@@ -279,6 +279,9 @@
                             (not (react-element? main-obj')))
                       (code-highlight (utils/pprint-code main-obj') "clojure")
                       main-obj')
+          ;; add the option to pass our (overridden-)`main` instead of inferring it.
+          ;; In the Om Next case this means passing the element where we mount
+          ;; the Om Next component.
           main      (cond
                       (not (nil? overridden-main))
                       overridden-main


### PR DESCRIPTION
this patch improves the recently added support for mounting Om Next components
into `devcards` by adding:

- a `defrecord` implementation of `IDevcard` specifically for Om Next components
- an `OmNextNode` that knows how to mount and reload Om Next components
  - this component builds on some of the logic that was in place, so a little
    code refactor was done in order to take advantage of some of that logic
  - with this is place, it is now possible to use Devcards options such as
    `:inspect-data`, `:history` and `watch-atom`(!)
- more examples to the `devdemos` pages which include a version of the BMI
  component (with `:inpect-data` and `:history` set to true) and a short note on
  how to write reloadable Om Next code