### PR TITLE
Added DataScript rendering support

### DIFF
--- a/src/devcards/core.cljs
+++ b/src/devcards/core.cljs
@@ -281,8 +281,9 @@
                     (hist-recorder* data-atom))
         document  (when-let [docu (:documentation card)]
                     (markdown->react docu))
+        render-fn (or (:render-fn options) identity)
         edn       (when (:inspect-data options)
-                    (edn-rend/html-edn @data-atom))
+                    (edn-rend/html-edn (render-fn @data-atom)))
         ;; only documentation?
         card      (if (or (string? main)
                           (nil? main))

--- a/src/devcards/util/utils.cljs
+++ b/src/devcards/util/utils.cljs
@@ -21,3 +21,25 @@
  
  (defn pprint-code [code]
    (pprint/with-pprint-dispatch pprint/code-dispatch (pprint-str code)))
+
+(defn ds->seq
+  "Renders a DataScript database in a way that Devcards can handle.
+   
+   Use this as the :render-fn parameter to `defcard-rg` when the devcards
+   data atom is a DataScript database.
+
+   Usage:
+   (defcard-rg my-card
+     \"Doesn't do much.\"
+     [:div]
+     datascript-conn
+     {:inspect-data true
+      :history      true
+      :render-fn    ds->seq})"
+  [db]
+  (->> db
+       (map (fn [d] {:e     (:e     d)
+                     :a     (:a     d)
+                     :v     (:v     d)
+                     :tx    (:tx    d)
+                     :added (:added d)}))))


### PR DESCRIPTION
- Added two lines of code in core.cljs in order to add the :render-fn
  parameter to e.g. `defcard-rg`
- Added one function to util/utils.cljs — `ds->seq` — in order to
  correctly render DataScript databases via Devcards. Provided
  documentation for this
