### PR TITLE
WIP: Global-exports to require React and support node modules

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,15 +1,15 @@
-(defproject devcards "0.2.4-SNAPSHOT"
+(defproject devcards "0.3.0-SNAPSHOT"
   :description "Devcards is a ClojureScript library that provides a lab space in which you can develop your UI components independently and interactively."
   :url "http://github.com/bhauman/devcards"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.229"]
-                 [org.clojure/core.async  "0.3.442" :exclusions [org.clojure/tools.reader]]
-                 [cljsjs/react "15.3.1-0"]
-                 [cljsjs/react-dom "15.3.1-0"]
-                 [sablono "0.7.4"]
+                 [org.clojure/clojurescript "1.9.908"]
+                 [org.clojure/core.async  "0.3.443" :exclusions [org.clojure/tools.reader]]
+                 [cljsjs/react "15.6.1-1"]
+                 [cljsjs/react-dom "15.6.1-1"]
+                 [sablono "0.8.0-SNAPSHOT"]
                  [cljs-react-reload "0.1.1"]
                  [cljsjs/showdown "0.4.0-1"]]
 
@@ -59,8 +59,8 @@
            :repl-options {:init (set! *print-length* 50)}}
    :dev {
       :dependencies [;[org.omcljs/om "0.9.0"]
-                     [org.omcljs/om "1.0.0-alpha46"]
-                     [reagent "0.6.0"]
+                     [org.omcljs/om "1.1.0-SNAPSHOT"]
+                     [reagent "0.8.0-alpha1"]
                      [figwheel-sidecar "0.5.8"]
                      [com.cemerick/piggieback "0.2.1"]
                      [org.clojure/tools.nrepl "0.2.12"]]                   

--- a/src/devcards/system.cljs
+++ b/src/devcards/system.cljs
@@ -9,8 +9,8 @@
    [goog.history.EventType :as EventType]
    [goog.labs.userAgent.device :as device]
    [devcards.util.utils :as utils :refer-macros [define-react-class]]
-   [cljsjs.react]
-   [cljsjs.react.dom])
+   [react :as react]
+   [react-dom :as react-dom])
   (:require-macros
    [cljs.core.async.macros :refer [go go-loop]]
    [devcards.system :refer [inline-resouce-file]])
@@ -326,8 +326,8 @@
 
 (defn renderer [state-atom]
   #_(prn "Rendering")
-  (js/ReactDOM.render
-   (js/React.createElement DevcardsRoot)
+  (react-dom/render
+   (react/createElement DevcardsRoot)
    #_(sab/html [:div
               (main-template state-atom)
               #_(edn-rend/html-edn @state-atom)])
@@ -417,8 +417,8 @@
 (defn start-ui-with-renderer [channel renderer]
   (defonce devcards-ui-setup
     (do
-      (when (exists? js/React.initializeTouchEvents)
-        (js/React.initializeTouchEvents true))
+      (when (exists? react/initializeTouchEvents)
+        (react/initializeTouchEvents true))
       (go
         (<! (load-data-from-channel! channel))
 
@@ -440,8 +440,8 @@
 (defn start-ui [channel]
   (defonce devcards-ui-setup
     (do
-      (when (exists? js/React.initializeTouchEvents)
-        (js/React.initializeTouchEvents true))
+      (when (exists? react/initializeTouchEvents)
+        (react/initializeTouchEvents true))
       (render-base-if-necessary!)
       (go
         ;; initial load
@@ -501,7 +501,7 @@
 </svg>")
 
 (defn cljs-logo []
-  (.span (.-DOM js/React)
+  (react/DOM.span
         (clj->js { :key "cljs-logo"
                   :dangerouslySetInnerHTML
                   { :__html


### PR DESCRIPTION
This is similar to https://github.com/reagent-project/reagent/pull/306
https://github.com/reagent-project/reagent/blob/master/CHANGELOG.md#080-alpha1-2017-07-31

I'm opening PR's on other related projects also:
- https://github.com/tonsky/rum/pull/148
- https://github.com/r0man/sablono/pull/175
- https://github.com/omcljs/om/pull/887

It is possible further changes to ClojureScript will make this change (partially) unnecessary: https://dev.clojure.org/jira/browse/CLJS-2331

Build causes lots of warnings:

```
WARNING: No such namespace: react, could not locate react.cljs, react.cljc, or JavaScript source providing "react" at line 37 example_src/devdemos/om_next.cljs
WARNING: Use of undeclared Var react/Component at line 37 example_src/devdemos/om_next.cljs
```

It is probably these are caused by problems in Om.

Some views work on browser, but there are some errors on console and at least om.next card is empty:

![image](https://user-images.githubusercontent.com/648087/29472673-899949be-845d-11e7-9371-9c558afaa906.png)

