### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ our site.
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="/css/{{your lib name}.css" rel="stylesheet" type="text/css">
+    <link href="/css/{{your lib name}}.css" rel="stylesheet" type="text/css">
   </head>
   <body>
     <div id="main-app-area"></div>


### PR DESCRIPTION
I think I found a missing `}`. Do you want it?