### PR TITLE
Iframe devcard (AKA a hack to use devcards with re-frame)

### DIFF
--- a/example_src/devdemos/re_frame.cljs
+++ b/example_src/devdemos/re_frame.cljs
@@ -1,0 +1,363 @@
+(ns devdemos.re-frame
+  (:require
+   [devcards.core]
+   [devcards.iframe :refer-macros [defcard-rg-iframe]]
+   [reagent.core :as reagent]
+   [re-frame.core :as re-frame])
+  (:require-macros
+    [reagent.ratom :refer [reaction]]
+    [devcards.core :as dc :refer [defcard defcard-rg defcard-doc]]))
+
+(defcard-doc
+  "
+## Rendering Re-frame components
+
+Note: The following examples assume a namespace that looks like this:
+
+```clojure
+(ns xxx
+    (:require [devcards.core]
+              [reagent.core :as reagent]
+              [re-frame.core :as re-frame])
+    (:require-macros [devcards.core :as dc
+                                    :refer [defcard defcard-rg]]))
+```
+")
+
+(defcard
+    "## Devcard Re-frame basics
+
+As re-frame uses a single global db, if we render multiple re-frame devcards
+on the same page, we can't make each of them to be based on a different app state.
+All of them would share the same app state, which is pretty boring... Unless we
+make each of them to be loaded inside of an iframe! And that's what we are going
+to show in the following examples.
+
+We'll use defcard-rg instead of plain defcard, because you know, re-frame components
+are usually reagent components")
+
+(defn re-frame-component-example []
+  (let [guest-name (re-frame/subscribe [:guest-name])]
+    [:div "Hi " @guest-name "!"]))
+
+(defn setup-example-1 []
+  (re-frame/reg-event-db
+    :initialize-db
+    (fn [db [_ data]]
+      data))
+
+  (re-frame/reg-event-db
+    :update-guest-name
+    (fn [db [_ guest-name]]
+      (assoc db :guest-name guest-name)))
+
+  (re-frame/reg-sub
+    :guest-name
+    (fn [db _]
+      (:guest-name db))))
+
+(defcard-rg-iframe re-frame-component
+  "This is a re-frame devcard not using data-atom, rendered in an iframe. It just says Hi! to our guest:"
+  (fn [data-atom _]
+    (setup-example-1)
+    (re-frame/dispatch [:update-guest-name "Peter"])
+    [re-frame-component-example]))
+
+(defcard-rg-iframe re-frame-component-initialize-db
+  "This is the same re-frame component, but now using data-atom to initialize the db, rendered in an iframe:"
+  (fn [data-atom _]
+    (setup-example-1)
+    (re-frame/dispatch [:initialize-db @data-atom])
+    [re-frame-component-example])
+  {:guest-name "John"})
+
+(defcard-rg re-frame-component-no-iframe
+  "Once again, the same simple re-frame component, but now rendered without using an iframe.
+  This example is only to show that we can't have more than one re-frame devcard
+  not using iframe, if we want them to be initialized with different state. Uncomment the following
+  devcard and you'll see how the app state is shared"
+  (fn [data-atom _]
+    (setup-example-1)
+    (re-frame/dispatch [:update-guest-name "Mary"])
+    [re-frame-component-example]))
+
+#_(defcard-rg re-frame-component-no-iframe-2
+  "When uncommented, this devcard shows that you can't have two re-frame devcards using separate
+  app state without using iframe. See how both guests are called the same!"
+  (fn [data-atom _]
+    (setup-example-1)
+    (re-frame/dispatch [:update-guest-name "Alice"])
+    [re-frame-component-example]))
+
+#_(defcard
+  "# Devcards helpers
+
+Devcards provides two macros to help you use reagent.
+
+* `devcards.core/reagent`
+* `devcards.core/defcard-rg`
+
+The `devcards.core/reagent` macro just calls `as-element` so the
+following works just like above.
+
+```clojure
+(defcard reagent-macro-1
+  (dc/reagent [:div \"This works fine\"]))
+```
+
+If you pass a function of 2 arguments to the `devcards.core/reagent`
+macro it will behave just like passing a function as the main object to `defcard`.
+
+```clojure
+(defcard reagent-macro-2
+  (dc/reagent (fn [data-atom _] [:div \"this works as well\"])))
+```
+
+I'll explore uses for this in just a bit.
+
+Since typing `(defcard reagent-macro-1 (dc/reagent ...))` is a tad
+verbose Devcards provides the `devcards.core/defcard-rg` macro.
+
+With `defcard-rg` you can create all the above examples without
+explicitly calling `dc/reagent`.
+
+The following two examples work and are a bit cleaner:
+
+
+```clojure
+(defcard-rg rg-example-2
+  \"some docs\"
+  [:div \"this works\"])
+
+(defcard-rg rg-example
+  \"some docs\"
+  (fn [data-atom _] [:div \"this works as well\"])
+  (reagent/atom {:counter 5}))
+```
+
+Alright let's look at some more examples:
+
+
+")
+
+;; counter 1
+
+(defn setup-counter1 []
+  (re-frame/reg-event-db :initialize-db
+    (fn [db [_ data]] data))
+
+  (re-frame/reg-event-db :increment-counter
+    (fn [db _] (update db :counter inc)))
+
+  (re-frame/reg-sub
+    :counter
+    (fn [db _]
+      (:counter db))))
+
+(defn counter1 []
+  (let [counter (re-frame/subscribe [:counter])]
+    [:div "Current count: " @counter
+     [:div
+      [:button {:on-click #(re-frame/dispatch [:increment-counter])}
+       "Increment"]]]))
+
+(defcard-rg-iframe counter1-card
+  "
+## Counter1 (Basic)
+
+The simplest way to create a re-frame devcard is to pass the `defcard-rg-iframe` macro a function
+that takes the data atom, initializes the re-frame app and whatever state is interesting for this
+card and then returns a reagent component:
+
+```clojure
+(defn setup-counter1 []
+  (re-frame/reg-event-db :initialize-db
+    (fn [db [_ data]] data))
+
+  (re-frame/reg-event-db :increment-counter
+    (fn [db _] (update db :counter inc)))
+
+  (re-frame/reg-sub
+    :counter
+    (fn [db _]
+      (:counter @db))))
+
+(defn counter1 []
+  (let [counter (re-frame/subscribe [:counter])]
+    [:div \"Current count: \" @counter
+     [:div
+      [:button {:on-click #(dispatch [:increment-counter])}
+       \"Increment\"]]]))
+```
+"
+  (fn [data-atom _]
+    (setup-counter1)
+    (re-frame/dispatch [:initialize-db @data-atom])
+    [counter1])
+  {:counter 0})
+
+;; counter 2
+
+#_(defonce counter2-state (reagent/atom {:count 0}))
+
+#_(defn counter2 []
+  [:div "Current count: " (@counter2-state :count)
+   [:div
+    [:button {:on-click #(on-click counter2-state)}
+     "Increment"]]])
+
+#_(defcard-rg counter2
+  "
+## Counter 2 (Displaying the state of reagent atom/cursor)
+
+However, wouldn't it be nice to see the state of our component? To
+accomplish this, we can pass the following arguments to the defcard
+macro:
+
+1) a reagent component (i.e., `counter2`) wrapped by square brackets
+
+2) the reagent atom (or cursor) that holds the state of our component (i.e., `counter2-state`)
+
+3) a hash-map of options, where we set inspect-data to true (i.e., `{:inspect-data :true}`}
+
+```clojure
+(defn on-click [ratom]
+  (swap! ratom update-in [:count] inc))
+
+(defonce counter2-state (reagent/atom {:count 0}))
+
+(defn counter2 []
+  [:div \"Current count: \" (@counter2-state :count)
+   [:div
+    [:button {:on-click #(on-click counter2-state)}
+    \"Increment\"]]])
+
+(defcard-rg counter2
+  [counter2] ;; <-- 1
+  counter2-state ;; <-- 2
+  {:inspect-data true} ;; <-- 3
+  )
+```
+"
+  [counter2] ;; <-- 1
+  counter2-state ;; <-- 2
+  {:inspect-data true} ;; <-- 3
+  )
+
+;; counter 3
+
+
+#_(defonce counter3-state (reagent/atom {:count 0}))
+
+#_(defn counter3 [ratom]
+  [:div "Current count: " (@ratom :count)
+   [:div
+    [:button {:on-click #(on-click ratom)}
+     "Increment"]]])
+
+#_(defcard-rg counter3
+  "
+## Counter 3 (Passing in an argument to the reagent component)
+
+At this point, you may be wondering, *how do we pass in arguments to
+the reagent component itself?* All you have to do is pass in your
+reagent component along with it's args.
+
+```clojure
+(defn on-click [ratom]
+  (swap! ratom update-in [:count] inc))
+
+(defonce counter3-state (reagent/atom {:count 0}))
+
+(defn counter3 [ratom] ;; <-- counter2 expects one argument
+  [:div \"Current count: \" (@ratom :count)
+   [:div
+    [:button {:on-click #(on-click ratom)}
+    \"Increment\"]]])
+
+(defcard-rg counter3
+  [counter3 counter3-state] ;; <-- passing in a ratom (counter3-state) to our reagent component (counter3)
+  counter3-state ;; <-- notice that we are *still* passing in a 2nd argument to defcard!
+  {:inspect-data true}
+  )
+```
+"
+  [counter3 counter3-state]
+  counter3-state
+  {:inspect-data true}
+  )
+
+
+;; counter 4
+
+#_(defonce counter4-state (reagent/atom {:count 0}))
+
+#_(defn counter4 [ratom
+                {:keys [title button-text]}]
+  [:div [:h3 title]
+   [:div "Current count: " (@ratom :count)]
+   [:div [:button {:on-click #(on-click ratom)}
+          button-text]]])
+
+#_(defcard-rg counter4
+  "
+## Counter 4 (Passing in multiple arguments to the reagent component)
+
+We can pass in an arbitray number of arguments to our reagent component if we wrap it in square brackets.
+
+```clojure
+(defn on-click [ratom]
+  (swap! ratom update-in [:count] inc))
+
+(defonce counter4-state (reagent/atom {:count 0}))
+
+(defn counter4 [ratom
+               {:keys [title button-text]}] ;; <-- counter4 expects two arguments: a ratom, and a hash-map
+  [:div [:h3 title]
+   [:div \"Current count: \" (@ratom :count)]
+   [:div [:button {:on-click #(on-click ratom)}
+          button-text]]])
+
+(defcard-rg counter4
+  [counter4 counter4-state
+                       {:title \"Counter 4\"
+                        :button-text \"INCREMENT\"}] ;; <-- passing in two arguments to our reagent component
+  counter4-state ;; <-- notice that we are *still* passing in a 2nd argument to defcard!
+  {:inspect-data true}
+  )
+```
+"
+  [counter4 counter4-state {:title "Counter 4"
+                                        :button-text "INCREMENT"}]
+  counter4-state
+  {:inspect-data true}
+  )
+
+#_(defcard-rg isolating-state
+  "## Isolating state
+
+  You may only want to have state available to your example code. This is accomplished in the following example:
+
+  ```clojure
+  (defcard-rg isolating-state
+    (fn [data-atom _]
+      [counter4 data-atom {:title \"Counter 5\"
+                           :button-text \"increment isolated state\"}])
+    (reagent/atom {:count 0}) ; <-- intial ratom
+    {:inspect-data true})
+  ```
+
+"
+  (fn [data-atom _]
+    [counter4 data-atom {:title "Counter 5"
+                         :button-text "increment isolated state"}])
+  (reagent/atom {:count 0}) ; <-- intial ratom
+  {:inspect-data true})
+
+
+
+
+
+
+
+

--- a/example_src/devdemos/start_ui.cljs
+++ b/example_src/devdemos/start_ui.cljs
@@ -5,6 +5,7 @@
    [devdemos.om]
    [devdemos.om-next]
    [devdemos.reagent]
+   [devdemos.re-frame]
    [devdemos.source-code-display]
    [devdemos.two-zero]
    [devdemos.testing]

--- a/project.clj
+++ b/project.clj
@@ -60,6 +60,7 @@
       :dependencies [;[org.omcljs/om "0.9.0"]
                      [org.omcljs/om "1.0.0-alpha46"]
                      [reagent "0.6.0"]
+                     [re-frame "0.10.2"]
                      [figwheel-sidecar "0.5.8"]
                      [com.cemerick/piggieback "0.2.1"]
                      [org.clojure/tools.nrepl "0.2.12"]]                   

--- a/resources/public/devcards/css/com_rigsomelight_devcards.css
+++ b/resources/public/devcards/css/com_rigsomelight_devcards.css
@@ -9,6 +9,10 @@ body .hljs {
 }
   
 #com-rigsomelight-devcards-main {
+    padding-bottom: 0;
+}
+
+#com-rigsomelight-devcards-main.no-standalone {
     padding-bottom: 10em;
 }
 

--- a/resources/public/devcards/css/com_rigsomelight_devcards.css
+++ b/resources/public/devcards/css/com_rigsomelight_devcards.css
@@ -164,6 +164,9 @@ body .hljs {
    border: 1px solid transparent;
 }
 
+.com-rigsomelight-devcards-card-base-no-pad.com-rigsomelight-devcards-card-no-top-margin {
+   margin-top: 0;
+}
 
 .com-rigsomelight-devcards-breadcrumbs {
     font-size: 16px;

--- a/src/devcards/core.clj
+++ b/src/devcards/core.clj
@@ -140,13 +140,14 @@
 
 ;; reagent helpers
 
-(defmacro reagent [body]
-  `(create-idevcard
-    (let [v# ~body]
-      (if (fn? v#)
-        (fn [data-atom# owner#] (reagent.core/as-element [v# data-atom# owner#]))
-        (reagent.core/as-element v#)))
-    {}))
+(defmacro reagent [body & [options]]
+  (let [options (or options {})]
+    `(create-idevcard
+      (let [v# ~body]
+        (if (fn? v#)
+          (fn [data-atom# owner#] (reagent.core/as-element [v# data-atom# owner#]))
+          (reagent.core/as-element v#)))
+      ~options)))
 
 (defmacro defcard-rg [& exprs]
   (when (utils/devcards-active?)

--- a/src/devcards/core.cljs
+++ b/src/devcards/core.cljs
@@ -275,7 +275,8 @@
   (let [options   (:options card)
         hist-ctl  (when (:history options)
                     (hist-recorder* data-atom))
-        document  (when-let [docu (:documentation card)]
+        document  (when-let [docu (and (not (:hide-documentation options))
+                                       (:documentation card))]
                     (markdown->react docu))
         edn       (when (:inspect-data options)
                     (edn-rend/html-edn @data-atom))
@@ -422,7 +423,7 @@
                       {:label :initial-data
                        :message "should be an Atom or a Map or nil."
                        :value initial-data})]
-                 (mapv #(booler? % (:options opts)) [:frame :heading :padding :inspect-data :watch-atom :history :static-state :show-standalone-link])))))
+                 (mapv #(booler? % (:options opts)) [:frame :heading :padding :inspect-data :watch-atom :history :static-state :show-standalone-link :hide-documentation])))))
     [{:message "Card should be a Map."
       :value   opts}]))
 

--- a/src/devcards/core.cljs
+++ b/src/devcards/core.cljs
@@ -186,14 +186,21 @@
            {:key "devcards_frame-normal-body"}
            (if path
              (sab/html
-              [:a
-               {:href "#"
-                :onClick
-                (devcards.system/prevent->
-                 #(devcards.system/set-current-path!
-                   devcards.system/app-state
-                   path))}
-               (name (last path))  " "])
+              [:div
+               [:a
+                {:href "#"
+                 :onClick
+                 (devcards.system/prevent->
+                   #(devcards.system/set-current-path!
+                      devcards.system/app-state
+                      [path]))}
+                (name (last path))  " "]
+               (when (:show-standalone-link options)
+                 (let [standalone-path (devcards.system/path->token path {:standalone true})]
+                   [:a
+                    {:href (str "#" standalone-path)
+                     :style #js {:fontSize "0.8em"}}
+                    "(standalone)"]))])
              (sab/html [:span (:name card)]))]
           (naked-card children card)]))
       (sab/html [:span])))))
@@ -415,7 +422,7 @@
                       {:label :initial-data
                        :message "should be an Atom or a Map or nil."
                        :value initial-data})]
-                 (mapv #(booler? % (:options opts)) [:frame :heading :padding :inspect-data :watch-atom :history :static-state])))))
+                 (mapv #(booler? % (:options opts)) [:frame :heading :padding :inspect-data :watch-atom :history :static-state :show-standalone-link])))))
     [{:message "Card should be a Map."
       :value   opts}]))
 
@@ -860,7 +867,7 @@
             (dev/prevent->
              #(devcards.system/set-current-path!
                devcards.system/app-state
-                path))}
+                [path]))}
           (when path (str (name (last path))) )]
          [:button.com-rigsomelight-devcards-badge
           {:style {:float "right"

--- a/src/devcards/core.cljs
+++ b/src/devcards/core.cljs
@@ -177,6 +177,8 @@
          [:div
           {:key (prn-str path)
            :class (str "com-rigsomelight-devcards-card-base-no-pad "
+                       (when (:no-top-margin options)
+                         " com-rigsomelight-devcards-card-no-top-margin")
                        (when (:hide-border options)
                          " com-rigsomelight-devcards-card-hide-border"))}
           (naked-card children card)])
@@ -423,7 +425,7 @@
                       {:label :initial-data
                        :message "should be an Atom or a Map or nil."
                        :value initial-data})]
-                 (mapv #(booler? % (:options opts)) [:frame :heading :padding :inspect-data :watch-atom :history :static-state :show-standalone-link :hide-documentation])))))
+                 (mapv #(booler? % (:options opts)) [:frame :heading :padding :inspect-data :watch-atom :history :static-state :show-standalone-link :hide-documentation :no-top-margin])))))
     [{:message "Card should be a Map."
       :value   opts}]))
 
@@ -434,6 +436,7 @@
                              :initial-data {}
                              :frame true
                              :heading false
+                             :no-top-margin false
                              :padding false
                              :inspect-data true
                              :static-state false

--- a/src/devcards/iframe.clj
+++ b/src/devcards/iframe.clj
@@ -1,0 +1,24 @@
+(ns devcards.iframe
+  (:require
+   [devcards.core :as devcards]
+   [devcards.util.utils :as utils]))
+
+(defmacro defcard-rg-iframe [& exprs]
+  (when (utils/devcards-active?)
+    (let [[vname docu main initial-data options] (devcards/parse-card-args exprs 'reagent-card)
+          options (assoc options
+                         :watch-atom false)]
+      (devcards/card vname docu `(if (:standalone devcards.system/*devcard-data*)
+                                   (devcards.core/reagent ~main {:heading false
+                                                                 :no-top-margin true
+                                                                 :hide-border true
+                                                                 :hide-documentation true
+                                                                 :history false
+                                                                 :inspect-data false})
+                                   (devcards.core/create-idevcard
+                                     (let [opts# {:name ~(name vname)
+                                                  :path (:path devcards.system/*devcard-data*)
+                                                  :options ~options}]
+                                       (devcards.iframe/devcard-iframe opts#))
+                                     {:show-standalone-link true}))
+                     initial-data options))))

--- a/src/devcards/iframe.cljs
+++ b/src/devcards/iframe.cljs
@@ -1,0 +1,57 @@
+(ns devcards.iframe
+  (:require
+   [sablono.core :as sab :include-macros true]
+   [devcards.core :refer [ref->node get-props get-state]]
+   [devcards.util.utils :as utils :refer [html-env?]
+    :refer-macros [define-react-class define-react-class-once]]))
+
+(define-react-class-once AutoResizeIFrame
+  (constructor
+    [props]
+    (this-as this
+      (set! (.-state this) #js {:unique_id (gensym 'auto-resize-iframe-)})))
+  (componentDidMount
+    [this]
+    (let [node (ref->node this (get-state this :unique_id))]
+      (.setState
+        this
+        #js {:resize_interval
+             (js/setInterval
+               (fn []
+                 (when-let [content-window (.-contentWindow node)]
+                   (let [height (min 700 (-> content-window
+                                             .-document
+                                             .-body
+                                             .-scrollHeight))]
+                     (set! (.-height node) height))))
+               1000)})))
+  (componentWillUnmount
+    [this]
+    (let [interval (get-state this :resize_interval)]
+      (js/clearInterval interval)))
+  (render
+    [this]
+    (sab/html
+      [:iframe (-> (js->clj (.-props this))
+                   (assoc :ref (get-state this :unique_id)))])))
+
+
+(define-react-class-once DevcardIFrame
+  (render
+    [this]
+    (let [card (get-props this :card)
+          path (:path card)
+          standalone-path (devcards.system/path->token path {:standalone true})
+          card-name (name (last path))]
+      (sab/html
+        [:div.com-rigsomelight-devcards-base.com-rigsomelight-devcards-card-base-no-pad.com-rigsomelight-devcards-card-hide-border
+         {:key (prn-str path)}
+         (js/React.createElement AutoResizeIFrame
+                                 #js {:src (str "#" standalone-path)
+                                      :name card-name
+                                      :height 50
+                                      :style {:border "none"
+                                              :width "100%"}})]))))
+
+(defn devcard-iframe [card]
+  (js/React.createElement DevcardIFrame #js {:card card}))


### PR DESCRIPTION
Implements a new kind of devcard that renders the content of the devcard (the "naked card") inside of an iframe, giving the devcard an isolated runtime with respect to other devcards and thus avoiding much of the issues that come from using global state.

This solves a pain point with the re-frame and devcards combination: there is no sane way to render devcards for components from a re-frame app that interact with the app db, when it is desired to render multiple devcards on the same page initialized with different app state.

Even though much of the components from a re-frame app can be rendered as simple reagent devcards, some components will unavoidable depend on db subscriptions (at some point data from the db has to be streamed into the view components) and we might want to render some of those components as devcards. As we are doing that, we probably want to render multiple devcards with different interesting app states. For example: an empty todo list, a todo list with 1 item, and a todo list with 20 items!

This implementation introduces a new "standalone" route: By adding `{:standalone true}` to a devcard route (the one that's set as the current route when clicking on a devcard title), the devcard can be rendered as a "naked card" - no breadcrumb, no devcard title, and other stuff is removed. This gives us a way to implement an iframe devcard that points the iframe to this standalone route: this way the content of the devcard is isolated from the rest of the devcards and devcards system, and we are safe to initialize the re-frame app, dispatching initialization events as needed, registering handlers and subscriptions, and even dispatching from events triggered in the devcard components.

I've added some examples under a new `devdemos.re-frame` ns.

Fixes #105