### PR TITLE
add macro self requires so they are always accessible via :refer

### DIFF
--- a/src/devcards/core.cljs
+++ b/src/devcards/core.cljs
@@ -3,8 +3,8 @@
    [devcards.system :as dev]
 
    [devcards.util.markdown :as mark]
-   [devcards.util.utils :as utils :refer [html-env?]
-    :refer-macros [define-react-class define-react-class-once]]
+   [devcards.util.utils :as utils
+    :refer [html-env? define-react-class define-react-class-once]]
 
    [sablono.core :as sab :include-macros true]
    [devcards.util.edn-renderer :as edn-rend]
@@ -13,6 +13,7 @@
    [cljs.test]
    [cljs.core.async :refer [put! chan timeout <! close! alts!] :as async])
   (:require-macros
+   [devcards.core]
    [cljs.core.async.macros :refer [go]]))
 
 (enable-console-print!)

--- a/src/devcards/system.cljs
+++ b/src/devcards/system.cljs
@@ -8,7 +8,7 @@
    [goog.events :as events]
    [goog.history.EventType :as EventType]
    [goog.labs.userAgent.device :as device]
-   [devcards.util.utils :as utils :refer-macros [define-react-class]]
+   [devcards.util.utils :as utils :refer [define-react-class]]
    [cljsjs.react]
    [cljsjs.react.dom])
   (:require-macros

--- a/src/devcards/util/utils.cljs
+++ b/src/devcards/util/utils.cljs
@@ -1,7 +1,9 @@
 (ns devcards.util.utils
   (:require
    [goog.object :as gobj]
-   [cljs.pprint :as pprint]))
+   [cljs.pprint :as pprint])
+  (:require-macros
+   [devcards.util.utils]))
 
 (defn html-env? []
   (if-let [doc js/goog.global.document]


### PR DESCRIPTION
CLJS expects that a namespace self-requires its macros (via `:require-macros`) to make them accessible directly (or via `:refer`). `shadow-cljs` follows this strictly but it sort of accidentally works with plain CLJS (and thereby all other CLJS build tools) if the macro was somehow required somewhere else. See [CLJS-2454](https://dev.clojure.org/jira/browse/CLJS-2454).

This PR adds the self-requires for the macro namespaces. This allows using `:refer` for both vars and macros.