### PR TITLE
Project data from `:inspect-data` with `:projection` option

### DIFF
--- a/example_src/devdemos/defcard_api.cljs
+++ b/example_src/devdemos/defcard_api.cljs
@@ -393,6 +393,7 @@
     :watch-atom true    ;; whether to watch the atom and render on change 
     :history false      ;; whether to record a change history of the atom
     :classname \"\"       ;; provide card with a custom classname
+    :projection identity ;; provide a projection function for card state
   }
   ```
 
@@ -437,6 +438,16 @@
                [:button {:onClick (fn [] (swap! data-atom update-in [:count] inc))} "inc"]]))
   {:count 50}
   {:inspect-data true :history true})
+
+(defcard project-data
+  (fn [data-atom _]
+    (sab/html [:div [:h3 "Inspecting data but only some of the data: Counter" (:count @data-atom)]
+               [:button {:onClick (fn [] (swap! data-atom update-in [:count] inc))} "inc"]
+               [:div "Random other state that is not important: " (:whatever @data-atom)]]))
+  {:count 50
+   :whatever "this state is present but not shown in `inspect-data` part."}
+  {:inspect-data true
+   :projection (fn [state] (select-keys state [:count]))})
 
 
 (defcard-doc

--- a/src/devcards/core.cljs
+++ b/src/devcards/core.cljs
@@ -266,12 +266,14 @@
 
 (defn render-all-card-elements [main data-atom card]
   (let [options   (:options card)
+        project   (or (:projection options)
+                      identity)
         hist-ctl  (when (:history options)
                     (hist-recorder* data-atom))
         document  (when-let [docu (:documentation card)]
                     (markdown->react docu))
         edn       (when (:inspect-data options)
-                    (edn-rend/html-edn @data-atom))
+                    (edn-rend/html-edn (project @data-atom)))
         ;; only documentation?
         card      (if (or (string? main)
                           (nil? main))


### PR DESCRIPTION
Somtimes card state is a bit more verbose than what is actually
interesting. This allows for a `:projection` option to manipulate the
data for the edn printout. Function of a single arity should be passed
the state atom.

```
(defcard reagent-support

  (dc/reagent re-bmi-component)
  re-bmi-data
  {:inspect-data true
   :projection (fn [bmi-data] :bmi)
   :frame true
   :history true })

```

This makes my life a bit nicer at the moment. I would like to add the ability to toggle the projection on and off so that one could see the entire data structure if so desired. At the moment you have to just comment out the `:projection` argument. I'll need to learn a bit more about the internals and the ui before I can do that though.

Let me know if you prefer a different option name. Also, I'm not sure how to extend validate-card-options to verify this, nor if there should be a bit more error handling in case the function does something wonky. You are very conscious of user experience and I don't want to negatively impact this.

Satisfies issue https://github.com/bhauman/devcards/issues/137

## Example: 
Before
![verbose](https://user-images.githubusercontent.com/6377293/40183277-0cf5f962-59b3-11e8-9682-70d2cf7246d6.png)

And After
![filtered](https://user-images.githubusercontent.com/6377293/40183300-19f190e0-59b3-11e8-8207-d2fc0d9d136d.png)
