### PR TITLE
Suggest new-style ns declarations for defcard macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,8 @@ Next you will need to include the Devcards macros into your file:
 ```clojure
 (ns example.core
   (:require
-   [sablono.core :as sab]) ; just for example
-  (:require-macros
-   [devcards.core :refer [defcard]]))
+   [sablono.core :as sab] ; just for example
+   [devcards.core :as dc :refer-macros [defcard]]))
 
 (defcard my-first-card
   (sab/html [:h1 "Devcards is freaking awesome!"]))
@@ -249,10 +248,8 @@ in this build adding the figwheel options doesn't help.
 ```clojure
 (ns example.core
   (:require
-   [devcards.core :as dc] ; <-- here
-   [sablono.core :as sab]) ; just for this example
-  (:require-macros
-   [devcards.core :refer [defcard]])) ; <-- and here
+   [sablono.core :as sab] ; just for this example
+   [devcards.core :as dc :refer-macros [defcard]]))
 
 (defcard my-first-card
   (sab/html [:h1 "Devcards is freaking awesome!"]))
@@ -297,9 +294,7 @@ our site.
 ```clojure
 (ns {{your lib name}}.core
   (:require
-   [devcards.core :as dc]) 
-  (:require-macros
-   [devcards.core :refer [defcard]])) 
+   [devcards.core :as dc :refer-macros [defcard]]))
 ```
 
 ### Start the Devcards UI in {{your lib name}}.core


### PR DESCRIPTION
The new ":refer-macros" syntax has been available for a while (it's explained [here](http://blog.fikesfarm.com/posts/2016-03-01-clojurescript-macro-sugar.html)). It makes the README easier to follow.