### PR TITLE
make d.core/dom-node* public

### DIFF
--- a/src/devcards/core.cljs
+++ b/src/devcards/core.cljs
@@ -526,7 +526,7 @@
                            opts)))))
 
 ;; keep
-(defn- dom-node* [node-fn]
+(defn dom-node* [node-fn]
   (fn [data-atom owner]
      (js/React.createElement DomComponent
                              #js {:node_fn   node-fn


### PR DESCRIPTION
With the stricter private method checking in ClojureScript, using devcards can cause Figwheel to halt automatic reloading because of the emitted warnings.

See https://github.com/grzm/figwheel-main-fulcro-devcards for a repro case.

Thanks to @awkay for debugging.