### PR TITLE
Fix devcards.core/card?

### DIFF
--- a/src/devcards/core.cljs
+++ b/src/devcards/core.cljs
@@ -83,10 +83,10 @@
 (defn card? [c]
   (and (map? c)
        (let [{:keys [path func]} c]
-         (vector? path)
-         (not-empty path)
-         (every? keyword? path)
-         (fn? func))))
+         (and (vector? path)
+              (not-empty path)
+              (every? keyword? path)
+              (fn? func)))))
 
 ;; could move into macros
 (defn register-card [c]


### PR DESCRIPTION
Missing an `and` in `devcards.core/card?`. Right now it ignores three of the four predicates in the `let`
expression. Only the last predicate, `fn?` will have any effect.
